### PR TITLE
Improve category flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,10 +10,14 @@
 <body>
   <header>
     <h1>ConnectWord</h1>
+    <div id="score">Score: 0</div>
   </header>
   <main id="game">
     <p>Select related words to form a group.</p>
-    <div id="word-grid"></div>
+    <div id="grid-container">
+      <div id="word-grid"></div>
+    </div>
+    <div id="message"></div>
     <button id="next-level" style="display:none">Next Level</button>
   </main>
   <script src="main.js"></script>

--- a/main.js
+++ b/main.js
@@ -4001,9 +4001,11 @@ const levels = [
   }
 ];
 
-let levelIndex = 0;
 let selected = [];
-let solvedCategories = new Set();
+let allGroups = [];
+let visibleGroups = [];
+let currentGroupIndex = 0;
+let score = 0;
 
 function shuffle(array) {
   for (let i = array.length - 1; i > 0; i--) {
@@ -4012,14 +4014,12 @@ function shuffle(array) {
   }
 }
 
-function renderLevel() {
+function renderBoard() {
   selected = [];
-  solvedCategories.clear();
   const grid = document.getElementById('word-grid');
   grid.innerHTML = '';
 
-  const level = levels[levelIndex];
-  const words = level.groups.flatMap(g => g.words);
+  const words = visibleGroups.flatMap(g => g.words);
   shuffle(words);
 
   for (const word of words) {
@@ -4033,7 +4033,6 @@ function renderLevel() {
 }
 
 function selectWord(btn) {
-  if (btn.classList.contains('solved')) return;
   const word = btn.textContent;
 
   if (btn.classList.contains('selected')) {
@@ -4047,20 +4046,23 @@ function selectWord(btn) {
 }
 
 function checkSelection() {
-  const level = levels[levelIndex];
-  const groupSize = level.groups[0].words.length;
+  if (visibleGroups.length === 0) return;
+  const groupSize = visibleGroups[0].words.length;
   if (selected.length !== groupSize) return;
 
   const selectionSet = new Set(selected);
-  for (const group of level.groups) {
-    if (!solvedCategories.has(group.category) &&
-        group.words.every(w => selectionSet.has(w))) {
-      markSolved(group.words);
-      solvedCategories.add(group.category);
-      if (solvedCategories.size === level.groups.length) {
-        document.getElementById('next-level').style.display = 'block';
+  for (let i = 0; i < visibleGroups.length; i++) {
+    const group = visibleGroups[i];
+    if (group.words.every(w => selectionSet.has(w))) {
+      score++;
+      updateScore();
+      showMessage(`Correct, ${group.category}`);
+      visibleGroups.splice(i, 1);
+      if (currentGroupIndex < allGroups.length) {
+        visibleGroups.push(allGroups[currentGroupIndex++]);
       }
       clearSelection();
+      renderBoard();
       return;
     }
   }
@@ -4076,23 +4078,24 @@ function clearSelection() {
   selected = [];
 }
 
-function markSolved(words) {
-  const grid = document.getElementById('word-grid');
-  for (const btn of grid.children) {
-    if (words.includes(btn.textContent)) {
-      btn.classList.remove('selected');
-      btn.classList.add('solved');
-      btn.disabled = true;
-    }
-  }
+function updateScore() {
+  document.getElementById('score').textContent = `Score: ${score}`;
+}
+
+function showMessage(msg) {
+  document.getElementById('message').textContent = msg;
 }
 
 function init() {
-  document.getElementById('next-level').addEventListener('click', () => {
-    levelIndex = (levelIndex + 1) % levels.length;
-    renderLevel();
-  });
-  renderLevel();
+  allGroups = levels.flatMap(l => l.groups);
+  shuffle(allGroups);
+  visibleGroups = allGroups.slice(0, 4);
+  currentGroupIndex = 4;
+  document.getElementById('next-level').style.display = 'none';
+  score = 0;
+  updateScore();
+  showMessage('');
+  renderBoard();
 }
 
 window.addEventListener('DOMContentLoaded', init);

--- a/styles.css
+++ b/styles.css
@@ -3,6 +3,8 @@ body {
   text-align: center;
   margin: 0;
   padding: 0;
+  background: #fafafa;
+  color: #333;
 }
 
 header {
@@ -11,28 +13,45 @@ header {
   padding: 1em;
 }
 
+#score {
+  margin-top: 0.5em;
+  font-size: 1.2em;
+}
+
 #word-grid {
   margin: 1em auto;
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+  grid-template-columns: repeat(3, 1fr);
   gap: 0.5em;
   max-width: 600px;
+}
+
+#grid-container {
+  padding: 0 1em;
+}
+
+#message {
+  margin-top: 1em;
+  font-weight: bold;
+  color: #2e7d32;
 }
 
 .word-btn {
   padding: 0.5em;
   border: 1px solid #3f51b5;
   border-radius: 4px;
-  background: #f5f5f5;
+  background: #fff;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.2);
   cursor: pointer;
+  transition: background 0.3s;
 }
 
 .word-btn.selected {
-  background: #cfe2ff;
+  background: #bbdefb;
 }
 
 .word-btn.solved {
-  background: #c8e6c9;
+  background: #dcedc8;
   cursor: default;
 }
 


### PR DESCRIPTION
## Summary
- show feedback when a category is solved
- swap solved words with the next category
- randomize category order each game
- keep word grid three columns wide
- add a running score and better styling

## Testing
- `node --version`
- `npm --version`


------
https://chatgpt.com/codex/tasks/task_e_688baf77ce58833192d321cc612b45ca