### PR TITLE
Allow 7 rows of words

### DIFF
--- a/main.js
+++ b/main.js
@@ -1490,8 +1490,8 @@ function showMessage(msg) {
 function init() {
   allGroups = levels.flatMap(l => l.groups);
   shuffle(allGroups);
-  visibleGroups = allGroups.slice(0, 4);
-  currentGroupIndex = 4;
+  visibleGroups = allGroups.slice(0, 7);
+  currentGroupIndex = 7;
   document.getElementById('next-level').style.display = 'none';
   score = 0;
   updateScore();


### PR DESCRIPTION
## Summary
- increase the number of active groups from four to seven so the grid shows 7 rows

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688bea6f48188331ae148a69a17f0600