### PR TITLE
Deduct points when hints are used

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
     <div id="score">Score: 0</div>
   </header>
   <main id="game">
-    <p>Three related words form a group. Stuck? Tap Hint.</p>
+    <p>Three related words form a group. Stuck? Tap Hint (costs 1 point).</p>
     <div id="grid-container">
       <div id="word-grid"></div>
     </div>

--- a/main.js
+++ b/main.js
@@ -1515,6 +1515,9 @@ function useHint() {
       const btn = Array.from(grid.children).find(b => b.textContent === nextWord);
       if (btn && !btn.classList.contains('selected')) {
         btn.classList.add('hinted');
+        score--;
+        updateScore();
+        showMessage('Hint used: -1 point');
       }
       break;
     }


### PR DESCRIPTION
## Summary
- Deduct a point and display a message whenever a hint is used, allowing scores to go negative.
- Update instructions to note that hints cost one point.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688d8c1a01d88331a0068ca35497ccf5